### PR TITLE
Update README.md to use `dart pub` instead of `pub`

### DIFF
--- a/webdev/README.md
+++ b/webdev/README.md
@@ -21,7 +21,7 @@ dev_dependencies:
 ["activated"][activating].
 
 ```console
-$ pub global activate webdev
+$ dart pub global activate webdev
 ```
 
 Learn more about activating and using packages [here][pub global].


### PR DESCRIPTION
The `pub` command no longer exist and users are therefore required to use `dart pub` instead for installation.